### PR TITLE
Drop pylint-gui

### DIFF
--- a/.circleci/run_docker_build.sh
+++ b/.circleci/run_docker_build.sh
@@ -29,7 +29,7 @@ if [ -z "$CONFIG" ]; then
     exit 1
 fi
 
-test -d "$ARTIFACTS" || mkdir "$ARTIFACTS"
+mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
 rm -f "$DONE_CANARY"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: python -m pip install --no-deps --ignore-installed .
   entry_points:
     - pylint = pylint:run_pylint

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,6 @@ build:
   script: python -m pip install --no-deps --ignore-installed .
   entry_points:
     - pylint = pylint:run_pylint
-    - pylint-gui = pylint:run_pylint_gui
     - epylint = pylint:run_epylint
     - pyreverse = pylint:run_pyreverse
     - symilar = pylint:run_symilar
@@ -48,11 +47,6 @@ test:
 
   commands:
     - pylint --help
-    # Needs to start a GUI with Tk.
-    # So running help is not even an option.
-    # Just check that it exists.
-    - which pylint-gui  # [unix]
-    - where pylint-gui  # [win]
     # Has no help option.
     # Running without arguments is an error.
     # So just check that it exists.


### PR DESCRIPTION
Dropping `pylint-gui` as it was dropped upstream in 1.7.0.

ref: https://github.com/PyCQA/pylint/blob/pylint-1.7.0/doc/whatsnew/1.7.rst

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
